### PR TITLE
SEO-2300 Angularjs Datepicker Missing H1 tag

### DIFF
--- a/angularjs/DatePicker/Behavior-Settings.md
+++ b/angularjs/DatePicker/Behavior-Settings.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Behavior Settings
-description: behavior settings
+title: Behavior Settings in AngularJS Datepicker control | Syncfusion
+description: Learn more about behavior settings in Syncfusion AngularJS Datepicker control, its elements, and more.
 platform: AngularJS
 control: Datepicker
 documnetation: ug
 ---
 
-# Behavior Settings
+# Behavior Settings in AngularJS Datepicker
 
 ## Set Value
 


### PR DESCRIPTION
Hi @ChristoIssac ,

Please review the changes for Angularjs Datepicker Missing H1 tag.

Regards,
Yvone.