### PR TITLE
seo-205214-Angular-H1-tag-Missing-hotfix 

### DIFF
--- a/angularjs/Autocomplete/textbox-customization.md
+++ b/angularjs/Autocomplete/textbox-customization.md
@@ -7,7 +7,7 @@ control: Autocomplete
 documentation: ug
 ---
 
-## Textbox Customization
+# Textbox Customization
 
 ### Auto-fill support
 

--- a/angularjs/Rotator/keyboard-interaction.md
+++ b/angularjs/Rotator/keyboard-interaction.md
@@ -7,7 +7,7 @@ control: rotator
 documentation: ug
 ---
 
-## Keyboard interaction
+# Keyboard interaction
 
 The Rotator property e-allowkeyboardnavigation turns on keyboard interaction with the Rotator items. You must set this property to ‘true’ to access the keyboard shortcuts. The default value is ‘true’. The value set to this property is Boolean.
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/205214/|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B13A50D72-C3C5-4635-90F2-E36DE3A8B07C%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it. |




Regards, 
Asha