### PR TITLE
seo-206704-Amgular-H1-tag-Missing-hotfix

### DIFF
--- a/angularjs/Autocomplete/textbox-customization.md
+++ b/angularjs/Autocomplete/textbox-customization.md
@@ -7,7 +7,7 @@ control: Autocomplete
 documentation: ug
 ---
 
-## Textbox Customization
+# Textbox Customization
 
 ### Auto-fill support
 

--- a/angularjs/Rotator/thumbnail.md
+++ b/angularjs/Rotator/thumbnail.md
@@ -7,7 +7,7 @@ control: rotator
 documentation: ug
 ---
 
-## Thumbnail
+# Thumbnail
 
 This feature implements Thumbnail in Rotator control. You can view or access any of the Rotator items instantly. All the images are given as Thumb Element to use this feature.
 
@@ -44,5 +44,5 @@ You can refer the following code example of Thumbnail in Rotator.
 
 
 
-![](thumbnail_images\previewthumbnail_img1.png)
+![thumbnail in rotator component.](thumbnail_images\previewthumbnail_img1.png)
 

--- a/angularjs/SunburstChart/Tooltip.md
+++ b/angularjs/SunburstChart/Tooltip.md
@@ -7,7 +7,7 @@ control: Sunburst Chart
 documentation: ug
 ---
 
-## Tooltip  
+# Tooltip  
 
 ToolTip allows you to display any information over a sunburst segment. It appears when mouse hovered over or touch any chart segment. By default, it displays the corresponding segment category name and its value
 
@@ -18,7 +18,7 @@ ToolTip allows you to display any information over a sunburst segment. It appear
 
 {% endhighlight %}
 
-![](Tooltip_images/Tooltip_img1.png)
+![mouse hovered over or touch any chart segment.](Tooltip_images/Tooltip_img1.png)
 
 ## Tooltip Template   
 
@@ -45,7 +45,7 @@ You can add a <div> element to set the `background` for the Sunburst chart and a
 
 {% endhighlight %}
 
-![](Tooltip_images/Tooltip_img2.png)
+![to display the x and y values of the corresponding point.](Tooltip_images/Tooltip_img2.png)
 
 ## Customize the appearance of tooltip
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/205214/|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B13A50D72-C3C5-4635-90F2-E36DE3A8B07C%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it. |
|Update the image alt tag| The image alt tag is important for SEO, so I updated it.|




Regards, 
Asha